### PR TITLE
Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ Make sure that your user is in the `input` group. If it's not already so, type t
 If it is still giving you troubles, you have to:  
 1. Create e new group `uinput` with the comand `sudo groupdadd -f uinput`  
 2. Add yourself to the new group with the comand `sudo gpasswd -a <user> uinput` (substitute <user> with your username)  
-3. In `/etc/udev/rules.d/` create a new rule file (for example `99-uinput.rules` and within put the row `KERNEL=="uinput", GROUP="uinput", MODE="0660"`)  
+3. In `/etc/udev/rules.d/` create a new rule file (for example `99-uinput.rules`) and within put the row `KERNEL=="uinput", GROUP="uinput", MODE="0660"`  
 4. Reboot  
  
-WARNING: you can also just always run the program as root, but understand that any scripts/files run by the program will ALSO be run as root, and generally this is a **BIG SECURITY THREAT!**
+**WARNING:** you can also just always run the program as root, but understand that any scripts/files run by the program will ALSO be run as root, and generally this is a **BIG SECURITY THREAT!**
 
 ## Usage
 If you already set the executable flag and put the program's folder in PATH then you can simply type `macropad.py`, else you need to type `python3 /full/path/to/macropad.py`, where `/full/path/to/` is the full path to the folder where you put the program file.
 
 `macropad.py -h` will show a short message help.
 
-While creating your config file in JSON format, make particular attention if you are grabbing the main keyboard that you use for input as this can lock you without a way to kill the program.
+While creating your config file in JSON format, make particular attention if you are grabbing the main keyboard that you use for input, as this can lock you without a way to kill the program.
 
 Assuming you have your config file created correctly;  
 1. If the config file is `~/.config/uinput-macropad/config.json` then you can simply run `macropad.py`  
-2. If the config file is elsewhere, then you have to run `macropad.py -f /full/path/to/<config file name>`  
+2. If the config file is elsewhere, then you have to run `macropad.py -c /full/path/to/<config file name>`  
 
 ## config file format
 There is an example config provided in this repo.
@@ -84,7 +84,7 @@ There are currently 4 different types of macros supported;
 6. `dispose`
     * Will dispose of events compelety when used in combination with `full_grab`
 
-If you want to find out more about what codes are sent when you can monitor your "main" keyboards output with `evtest`. In order to debug the output of your macros you can also monitor the output of the device created by this program with `evtest`.
+If you want to find out more about what codes are sent when you press keys, you can monitor your "main" keyboards output with `evtest`. In order to debug the output of your macros you can also monitor the output of the device created by this program with `evtest`.
 
 Each layer can be configured to be swapped to with the press of a button[s]. This is controlled in the `dev_name` variable. In order to determine the name of your device you can run `evtest` with it unplugged and then with it plugged in, comparing the list to find the new device.
 
@@ -138,7 +138,7 @@ Suggestions welcome!
 Prebuilt configs that are general enough to have mass appeal can be added as PRs if any one is adventerous enough to do so. 
 
 ## Breaking changes
-Nothing is guarnteed compatibitly wise 
+Nothing is guaranteed compatibitly wise 
 
 
 ## Too complicated?

--- a/macropad.py
+++ b/macropad.py
@@ -92,8 +92,7 @@ def check_held_keys(held_keys, macros):
 def get_macro_info(mname, layer):
     for macro in layer:
         if macro['name']==mname:
-            if(args.verbose):
-                log.info("MACRO FOUND")
+            log.debug("MACRO FOUND")
             return macro['type'], macro['info']
     return None
 

--- a/macropad.py
+++ b/macropad.py
@@ -41,6 +41,7 @@ PROGNAME = 'UInput Macropad'
 VERSION = '0.1'
 DEFAULT_CONFIG_FILE = '~/.config/uinput-macropad/config.json'
 LOG_FILE_PATH = '~/.local/state/'
+LOG_FILE_NAME = 'uinput-macropad'
 
 def get_devices():
     return [evdev.InputDevice(path) for path in evdev.list_devices()]
@@ -213,10 +214,10 @@ if __name__ == "__main__":
         log.setLevel(logging.WARNING)
     # Set log file's path
     log_file = os.path.expanduser(LOG_FILE_PATH)
-    log_file = os.path.join(log_file, PROGNAME)
+    log_file = os.path.join(log_file, LOG_FILE_NAME)
     if not os.path.isdir(log_file):
         os.makedirs(log_file)
-    log_file = os.path.join(log_file, PROGNAME + '.log')
+    log_file = os.path.join(log_file, LOG_FILE_NAME + '.log')
     # Max 3 files of ~1MB each
     handler = RotatingFileHandler(log_file, maxBytes=10**6, backupCount=3, encoding='utf-8')
     # Format of logging strings


### PR DESCRIPTION
All the print() are transformed in logging output, where the flag "-v" or "--verbose" set the log level to show all logs output instead of warning|error|critical only.
Only few important messages are also printed on STDOUT o STDERR.
The log file is created in "~/.local/state/UInput Macropad/UInput Macropad.log" as some people advise as a Linux standard.
It's a rotating log, with a principal file and max. 3 old backup, each one max. ~ 1MB, just like standard logs in /var/log, but smaller.

Besides this I corrected few typos/mistakes in README.md